### PR TITLE
Allow setting custom path for extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 node_modules
-dist
 xunit.xml

--- a/dist/downloadChromeExtension.js
+++ b/dist/downloadChromeExtension.js
@@ -1,0 +1,70 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _fs = require('fs');
+
+var _fs2 = _interopRequireDefault(_fs);
+
+var _path = require('path');
+
+var _path2 = _interopRequireDefault(_path);
+
+var _request = require('request');
+
+var _request2 = _interopRequireDefault(_request);
+
+var _rimraf = require('rimraf');
+
+var _rimraf2 = _interopRequireDefault(_rimraf);
+
+var _crossUnzip = require('cross-unzip');
+
+var _crossUnzip2 = _interopRequireDefault(_crossUnzip);
+
+var _utils = require('./utils');
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var downloadChromeExtension = function downloadChromeExtension(chromeStoreID, forceDownload) {
+  var attempts = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : 5;
+
+  var extensionsStore = (0, _utils.getPath)();
+  var extensionFolder = _path2.default.resolve(extensionsStore + '/' + chromeStoreID);
+  return new Promise(function (resolve, reject) {
+    if (!_fs2.default.existsSync(extensionFolder) || forceDownload) {
+      if (_fs2.default.existsSync(extensionFolder)) {
+        _rimraf2.default.sync(extensionFolder);
+      }
+      var fileURL = 'https://clients2.google.com/service/update2/crx?response=redirect&x=id%3D' + chromeStoreID + '%26uc&prodversion=32'; // eslint-disable-line
+      var download = _fs2.default.createWriteStream(_path2.default.resolve(extensionFolder + '.crx'));
+      (0, _request2.default)({
+        url: fileURL,
+        followAllRedirects: true,
+        timeout: 10000,
+        gzip: true
+      }).on('error', function (err) {
+        console.log('Failed to fetch extension, trying ' + (attempts - 1) + ' more times'); // eslint-disable-line
+        if (attempts <= 1) {
+          return reject(err);
+        }
+        setTimeout(function () {
+          downloadChromeExtension(chromeStoreID, forceDownload, attempts - 1).then(resolve).catch(reject);
+        }, 200);
+      }).pipe(download).on('close', function () {
+        (0, _crossUnzip2.default)(_path2.default.resolve(extensionFolder + '.crx'), extensionFolder, function (err) {
+          if (err && !_fs2.default.existsSync(_path2.default.resolve(extensionFolder, 'manifest.json'))) {
+            return reject(err);
+          }
+          resolve(extensionFolder);
+        });
+      });
+    } else {
+      resolve(extensionFolder);
+    }
+  });
+};
+
+exports.default = downloadChromeExtension;

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,0 +1,108 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.REACT_PERF = exports.REDUX_DEVTOOLS = exports.VUEJS_DEVTOOLS = exports.ANGULARJS_BATARANG = exports.JQUERY_DEBUGGER = exports.BACKBONE_DEBUGGER = exports.REACT_DEVELOPER_TOOLS = exports.EMBER_INSPECTOR = exports.setCustomPath = undefined;
+
+var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
+
+var _electron = require('electron');
+
+var _electron2 = _interopRequireDefault(_electron);
+
+var _fs = require('fs');
+
+var _fs2 = _interopRequireDefault(_fs);
+
+var _path = require('path');
+
+var _path2 = _interopRequireDefault(_path);
+
+var _semver = require('semver');
+
+var _semver2 = _interopRequireDefault(_semver);
+
+var _downloadChromeExtension = require('./downloadChromeExtension');
+
+var _downloadChromeExtension2 = _interopRequireDefault(_downloadChromeExtension);
+
+var _utils = require('./utils');
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
+exports.setCustomPath = _utils.setCustomPath;
+
+var _ref = _electron.remote || _electron2.default,
+    BrowserWindow = _ref.BrowserWindow;
+
+var IDMap = {};
+var IDMapPath = _path2.default.resolve((0, _utils.getPath)(), 'IDMap.json');
+if (_fs2.default.existsSync(IDMapPath)) {
+  IDMap = JSON.parse(_fs2.default.readFileSync(IDMapPath, 'utf8'));
+}
+
+exports.default = function (extensionReference) {
+  var forceDownload = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : false;
+
+  var chromeStoreID = void 0;
+  if ((typeof extensionReference === 'undefined' ? 'undefined' : _typeof(extensionReference)) === 'object' && extensionReference.id) {
+    chromeStoreID = extensionReference.id;
+    if (!_semver2.default.satisfies(process.versions.electron, extensionReference.electron)) {
+      return Promise.reject(new Error('Version of Electron: ' + process.versions.electron + ' does not match required range ' + extensionReference.electron + ' for extension ' + chromeStoreID));
+    }
+  } else if (typeof extensionReference === 'string') {
+    chromeStoreID = extensionReference;
+  } else {
+    return Promise.reject(new Error('Invalid extensionReference passed in: "' + extensionReference + '"'));
+  }
+  var extensionName = IDMap[chromeStoreID];
+  var extensionInstalled = extensionName && BrowserWindow.getDevToolsExtensions && BrowserWindow.getDevToolsExtensions()[extensionName];
+  if (!forceDownload && extensionInstalled) {
+    return Promise.resolve(IDMap[chromeStoreID]);
+  }
+  return (0, _downloadChromeExtension2.default)(chromeStoreID, forceDownload).then(function (extensionFolder) {
+    // Use forceDownload, but already installed
+    if (extensionInstalled) {
+      BrowserWindow.removeDevToolsExtension(extensionName);
+    }
+    var name = BrowserWindow.addDevToolsExtension(extensionFolder); // eslint-disable-line
+    _fs2.default.writeFileSync(IDMapPath, JSON.stringify(Object.assign(IDMap, _defineProperty({}, chromeStoreID, name))));
+    return Promise.resolve(name);
+  });
+};
+
+var EMBER_INSPECTOR = exports.EMBER_INSPECTOR = {
+  id: 'bmdblncegkenkacieihfhpjfppoconhi',
+  electron: '^1.2.1'
+};
+var REACT_DEVELOPER_TOOLS = exports.REACT_DEVELOPER_TOOLS = {
+  id: 'fmkadmapgofadopljbjfkapdkoienihi',
+  electron: '^1.2.1'
+};
+var BACKBONE_DEBUGGER = exports.BACKBONE_DEBUGGER = {
+  id: 'bhljhndlimiafopmmhjlgfpnnchjjbhd',
+  electron: '^1.2.1'
+};
+var JQUERY_DEBUGGER = exports.JQUERY_DEBUGGER = {
+  id: 'dbhhnnnpaeobfddmlalhnehgclcmjimi',
+  electron: '^1.2.1'
+};
+var ANGULARJS_BATARANG = exports.ANGULARJS_BATARANG = {
+  id: 'ighdmehidhipcmcojjgiloacoafjmpfk',
+  electron: '^1.2.1'
+};
+var VUEJS_DEVTOOLS = exports.VUEJS_DEVTOOLS = {
+  id: 'nhdogjmejiglipccpnnnanhbledajbpd',
+  electron: '^1.2.1'
+};
+var REDUX_DEVTOOLS = exports.REDUX_DEVTOOLS = {
+  id: 'lmhkpmbekcpmknklioeibfkpmmfibljd',
+  electron: '^1.2.1'
+};
+var REACT_PERF = exports.REACT_PERF = {
+  id: 'hacmcodfllhbnekmghgdlplbdnahmhmm',
+  electron: '^1.2.6'
+};

--- a/dist/utils.js
+++ b/dist/utils.js
@@ -1,0 +1,36 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.setCustomPath = exports.getPath = undefined;
+
+var _electron = require('electron');
+
+var _electron2 = _interopRequireDefault(_electron);
+
+var _fs = require('fs');
+
+var _fs2 = _interopRequireDefault(_fs);
+
+var _path = require('path');
+
+var _path2 = _interopRequireDefault(_path);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var customPath = null;
+
+var getPath = exports.getPath = function getPath() {
+  if (customPath) return customPath;
+  var savePath = (_electron.remote || _electron2.default).app.getPath('userData');
+  var extensionsStore = _path2.default.resolve(savePath + '/extensions');
+  if (!_fs2.default.existsSync(extensionsStore)) {
+    _fs2.default.mkdirSync(extensionsStore);
+  }
+  return extensionsStore;
+};
+
+var setCustomPath = exports.setCustomPath = function setCustomPath(p) {
+  customPath = p;
+};

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,9 @@ import path from 'path';
 import semver from 'semver';
 
 import downloadChromeExtension from './downloadChromeExtension';
-import { getPath } from './utils';
+import { getPath, setCustomPath } from './utils';
+
+export { setCustomPath };
 
 const { BrowserWindow } = remote || electron;
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,11 +2,18 @@ import electron, { remote } from 'electron';
 import fs from 'fs';
 import path from 'path';
 
+let customPath = null;
+
 export const getPath = () => {
+  if (customPath) return customPath;
   const savePath = (remote || electron).app.getPath('userData');
   const extensionsStore = path.resolve(`${savePath}/extensions`);
   if (!fs.existsSync(extensionsStore)) {
     fs.mkdirSync(extensionsStore);
   }
   return extensionsStore;
+};
+
+export const setCustomPath = (p) => {
+  customPath = p;
 };

--- a/test/download_spec.js
+++ b/test/download_spec.js
@@ -7,7 +7,8 @@ import path from 'path';
 
 // Actual Test Imports
 import downloadChromeExtension from '../src/downloadChromeExtension';
-import { REACT_DEVELOPER_TOOLS } from '../src/';
+import { REACT_DEVELOPER_TOOLS, setCustomPath } from '../src/';
+import { getPath } from '../src/utils';
 
 chai.use(chaiAsPromised);
 chai.use(chaiFs);
@@ -32,6 +33,13 @@ describe('Extension Downloader', () => {
           done();
         })
         .catch(err => done(err));
+    });
+
+    it('should use custom path when provided with one', () => {
+      const expected = '/fakePath';
+      setCustomPath(expected);
+      getPath().should.equal(expected);
+      setCustomPath(null);
     });
 
     describe('with the force parameter', () => {


### PR DESCRIPTION
This PR allows library user to set his own path to save extensions at.
This is useful for people who do not want to load extensions in production builds on development machines. User data folder is shared between dev and prod builds and makes prod builds load extensions.