### PR TITLE
Fix first run error caused by mkdir in getPath

### DIFF
--- a/src/downloadChromeExtension.js
+++ b/src/downloadChromeExtension.js
@@ -8,6 +8,9 @@ import { getPath } from './utils';
 
 const downloadChromeExtension = (chromeStoreID, forceDownload, attempts = 5) => {
   const extensionsStore = getPath();
+  if (!fs.existsSync(extensionsStore)) {
+    fs.mkdirSync(extensionsStore);
+  }
   const extensionFolder = path.resolve(`${extensionsStore}/${chromeStoreID}`);
   return new Promise((resolve, reject) => {
     if (!fs.existsSync(extensionFolder) || forceDownload) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,12 +1,7 @@
 import electron, { remote } from 'electron';
-import fs from 'fs';
 import path from 'path';
 
 export const getPath = () => {
   const savePath = (remote || electron).app.getPath('userData');
-  const extensionsStore = path.resolve(`${savePath}/extensions`);
-  if (!fs.existsSync(extensionsStore)) {
-    fs.mkdirSync(extensionsStore);
-  }
-  return extensionsStore;
+  return path.resolve(`${savePath}/extensions`);
 };


### PR DESCRIPTION
The mkdir in getPath gets executed on import whenever this library is used. This causes an error to be thrown when the electron app that uses it is freshly installed, and the electron userData directory is not yet created.

This change moves the mkdir call to the first place the existence of the extensionsStore is actually required.

Fixes #29