### PR TITLE
Updated readme to include require() example

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,16 @@ installExtension(REACT_DEVELOPER_TOOLS)
     .catch((err) => console.log('An error occurred: ', err));
 ```
 
+Alternatively, using `require()` and destructuring (node v6 or higher) you can
+
+```js
+const { default: installExtension, REACT_DEVELOPER_TOOLS } = require('electron-devtools-installer');
+
+installExtension(REACT_DEVELOPER_TOOLS)
+    .then((name) => console.log(`Added Extension:  ${name}`))
+    .catch((err) => console.log('An error occurred: ', err));
+```
+
 ## What extensions can I use?
 
 Technically you can use whatever extension you want.  Simply find the ChromeStore ID


### PR DESCRIPTION
Thank you for this tool, makes working with devtools in electron much easier. I saw there was a small bit of confusion around using `require()` within the issues (#39, #24) so I figured I would open a PR to include my usage of `require()` with electron-devtools-installer. I tried to match the tone of the readme as much as possible.