### PR TITLE
Updated cross-unzip and win-7zip

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,8 +47,8 @@
     "spec-xunit-file": "0.0.1-3"
   },
   "dependencies": {
-    "7zip": "0.0.6",
-    "cross-unzip": "0.0.2",
+    "win-7zip": "0.1.1",
+    "cross-unzip": "0.2.1",
     "rimraf": "^2.5.2",
     "semver": "^5.3.0"
   },


### PR DESCRIPTION
Updated cross-unzip and win-7zip to fix devtools installations and webpack errors on windows.