### PR TITLE
Change downloaded extension folder permissions

### DIFF
--- a/src/downloadChromeExtension.js
+++ b/src/downloadChromeExtension.js
@@ -3,7 +3,7 @@ import path from 'path';
 import rimraf from 'rimraf';
 import unzip from 'cross-unzip';
 
-import { getPath, downloadFile } from './utils';
+import { getPath, downloadFile, changePermissions } from './utils';
 
 const downloadChromeExtension = (chromeStoreID, forceDownload, attempts = 5) => {
   const extensionsStore = getPath();
@@ -23,6 +23,7 @@ const downloadChromeExtension = (chromeStoreID, forceDownload, attempts = 5) => 
           if (err && !fs.existsSync(path.resolve(extensionFolder, 'manifest.json'))) {
             return reject(err);
           }
+          changePermissions(extensionFolder, 755);
           resolve(extensionFolder);
         });
       }).catch((err) => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -26,3 +26,14 @@ export const downloadFile = (from, to) => new Promise((resolve, reject) => {
   req.on('error', reject);
   req.end();
 });
+
+export const changePermissions = (dir, mode) => {
+  const files = fs.readdirSync(dir);
+  files.forEach((file) => {
+    const filePath = path.join(dir, file);
+    fs.chmodSync(filePath, parseInt(mode, 8));
+    if (fs.statSync(filePath).isDirectory()) {
+      changePermissions(filePath, mode);
+    }
+  });
+};


### PR DESCRIPTION
Fix #63, the Chrome Store modified folder permissions for recently uploaded extensions.

I've triggered the CI build on my fork: [the latest commit on `master` is failed](https://travis-ci.org/jhen0409/electron-devtools-installer/builds/280027474).