### PR TITLE
React Perf Dev Tool

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -90,12 +90,8 @@ export const REDUX_DEVTOOLS = {
   electron: '^1.2.1',
 };
 export const REACT_PERF = {
-  id: 'hacmcodfllhbnekmghgdlplbdnahmhmm',
-  electron: '^1.2.6',
-};
-export const REACT_TOOL = {
   id: 'fcombecpigkkfcbfaeikoeegkmkjfbfm',
-  electron: '^1.2.1',
+  electron: '^1.2.6',
 };
 export const CYCLEJS_DEVTOOL = {
   id: 'dfgplfmhhmdekalbpejekgfegkonjpfp',

--- a/src/index.js
+++ b/src/index.js
@@ -93,6 +93,10 @@ export const REACT_PERF = {
   id: 'hacmcodfllhbnekmghgdlplbdnahmhmm',
   electron: '^1.2.6',
 };
+export const REACT_TOOL = {
+  id: 'fcombecpigkkfcbfaeikoeegkmkjfbfm',
+  electron: '^1.2.1',
+};
 export const CYCLEJS_DEVTOOL = {
   id: 'dfgplfmhhmdekalbpejekgfegkonjpfp',
   electron: '^1.2.1',


### PR DESCRIPTION
Since React Perf doesn't work for React 16 maybe it's better to use [React Performance Devtool](https://chrome.google.com/webstore/detail/react-performance-devtool/fcombecpigkkfcbfaeikoeegkmkjfbfm).