### PR TITLE
Use unzip-crx instead of cross-unzip and 7-zip

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,10 +48,9 @@
     "spec-xunit-file": "0.0.1-3"
   },
   "dependencies": {
-    "7zip": "0.0.6",
-    "cross-unzip": "0.0.2",
     "rimraf": "^2.5.2",
-    "semver": "^5.3.0"
+    "semver": "^5.3.0",
+    "unzip-crx": "^0.2.0"
   },
   "babel": {
     "presets": [

--- a/src/downloadChromeExtension.js
+++ b/src/downloadChromeExtension.js
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import rimraf from 'rimraf';
-import unzip from 'cross-unzip';
+import unzip from 'unzip-crx';
 
 import { getPath, downloadFile, changePermissions } from './utils';
 
@@ -19,12 +19,13 @@ const downloadChromeExtension = (chromeStoreID, forceDownload, attempts = 5) => 
       const fileURL = `https://clients2.google.com/service/update2/crx?response=redirect&x=id%3D${chromeStoreID}%26uc&prodversion=32`; // eslint-disable-line
       const filePath = path.resolve(`${extensionFolder}.crx`);
       downloadFile(fileURL, filePath).then(() => {
-        unzip(filePath, extensionFolder, (err) => {
-          if (err && !fs.existsSync(path.resolve(extensionFolder, 'manifest.json'))) {
-            return reject(err);
-          }
+        unzip(filePath, extensionFolder).then(() => {
           changePermissions(extensionFolder, 755);
           resolve(extensionFolder);
+        }).catch((err) => {
+          if (!fs.existsSync(path.resolve(extensionFolder, 'manifest.json'))) {
+            return reject(err);
+          }
         });
       }).catch((err) => {
         console.log(`Failed to fetch extension, trying ${attempts - 1} more times`); // eslint-disable-line


### PR DESCRIPTION

Based on a possible fix to issue #55 that was implemented back in July, mentioned here: https://github.com/nklayman/vue-cli-plugin-electron-builder/pull/35#issuecomment-407164967 but unfortunately not submitted as a PR.
Running prettier on https://github.com/MarshallOfSound/electron-devtools-installer/blob/master/src/downloadChromeExtension.js and https://github.com/nklayman/vue-cli-plugin-electron-builder/blob/master/lib/installVueDevtools/downloadChromeExtension.js and then comparing them revealed that the fix was based on using unzip-crx instead of cross-unzip and 7-zip. 
Made some additional adjustments related to error rejection so that the tests pass.

Please test as see if this indeed fixes #55.

Also fixes #27