### PR TITLE
Improve the getting started instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,17 @@ yarn add electron-devtools-installer -D
 ```
 
 ## Usage
-All you have to do now is
+In your `electron-starter.js` file, add the following callback to `app.on('ready', ... )`,
 
 ```js
-import installExtension, { REACT_DEVELOPER_TOOLS } from 'electron-devtools-installer';
+const { default: installExtension, REDUX_DEVTOOLS } = require('electron-devtools-installer');
+const { app, BrowserWindow } = require('electron');
 
-installExtension(REACT_DEVELOPER_TOOLS)
-    .then((name) => console.log(`Added Extension:  ${name}`))
-    .catch((err) => console.log('An error occurred: ', err));
+app.on('ready', () => {
+    installExtension(REDUX_DEVTOOLS)
+        .then((name) => console.log(`Added Extension:  ${name}`))
+        .catch((err) => console.log('An error occurred: ', err));
+});
 ```
 
 Alternatively, using `require()` and destructuring (node v6 or higher) you can

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ app.on('ready', () => {
         .catch((err) => console.log('An error occurred: ', err));
 });
 ```
+To install multiple extensions, `installExtension` takes an array.
 
 Alternatively, using `require()` and destructuring (node v6 or higher) you can
 


### PR DESCRIPTION
To resolve issue https://github.com/MarshallOfSound/electron-devtools-installer/issues/75, which ranks position number 2 for me in Google when searching for "electron-devtools-installer", and https://github.com/MarshallOfSound/electron-devtools-installer/issues/96.

I also had issue with the instructions and bounced around the web more than I should have needed to do. For example, before this change, it's not clear if this code belongs in the `electron-starter.js` file, or inside the application code itself. It was from this documentation that I found the key info: https://electronjs.org/docs/tutorial/devtools-extension

It would also be good to specify if `installExtension` takes multiple arguments, allowing us to load multiple extensions, or if it needs to be called multiple times, in which case the example would show the use of
```js
Promise.all([
    installExtension(REDUX_DEVTOOLS),
    installExtension(REACT_DEVELOPER_TOOLS),
])
.then((name) => console.log(`Added Extension:  ${name}`))
.catch((err) => console.log('An error occurred: ', err));
```