### PR TITLE
fix: electron import follows ES6 module spec

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import electron, { remote } from 'electron';
+import * as electron from 'electron';
 import fs from 'fs';
 import path from 'path';
 import semver from 'semver';
@@ -6,7 +6,7 @@ import semver from 'semver';
 import downloadChromeExtension from './downloadChromeExtension';
 import { getPath } from './utils';
 
-const { BrowserWindow } = remote || electron;
+const { BrowserWindow } = electron.remote || electron;
 
 let IDMap = {};
 const getIDMapPath = () => path.resolve(getPath(), 'IDMap.json');

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,15 +1,15 @@
-import electron, { remote } from 'electron';
+import * as electron from 'electron';
 import fs from 'fs';
 import path from 'path';
 import https from 'https';
 
 export const getPath = () => {
-  const savePath = (remote || electron).app.getPath('userData');
+  const savePath = (electron.remote || electron).app.getPath('userData');
   return path.resolve(`${savePath}/extensions`);
 };
 
 // Use https.get fallback for Electron < 1.4.5
-const { net } = (remote || electron);
+const { net } = (electron.remote || electron);
 const request = net ? net.request : https.get;
 
 export const downloadFile = (from, to) => new Promise((resolve, reject) => {


### PR DESCRIPTION
Current import code along with electron/electron#20910 causes Webpack to try and return require('electron').default as the import which does not exist. This pull request changes the import code to comform strictly to ES6 module spec so it wouldn't matter if Electron erroneously exports __esModule.