### PR TITLE
feat: add support for new session extension handling in Electron 9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,9 @@ workflows:
       - test-electron:
           name: test-electron-8
           electron_version: ^8.0.0
+      - test-electron:
+          name: test-electron-9
+          electron_version: ^9.0.0
       - release:
           requires:
             - test-electron-4
@@ -59,6 +62,7 @@ workflows:
             - test-electron-6
             - test-electron-7
             - test-electron-8
+            - test-electron-9
           filters:
             branches:
               only:


### PR DESCRIPTION
Electron 9 deprecates the use of BrowserWindow extension handling so I implemented the new way for handling extensions.

See here:
- [BrowserWindow.getDevToolsExtensions()](https://www.electronjs.org/docs/api/browser-window#browserwindowgetdevtoolsextensions-deprecated)
- [BrowserWindow.addDevToolsExtension(path)](https://www.electronjs.org/docs/api/browser-window#browserwindowadddevtoolsextensionpath-deprecated)
- [BrowserWindow.removeDevToolsExtension(name)](https://www.electronjs.org/docs/api/browser-window#browserwindowremovedevtoolsextensionname-deprecated)