### PR TITLE
Add CRX3 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "dependencies": {
     "rimraf": "^3.0.2",
     "semver": "^7.2.1",
-    "unzip-crx": "^0.2.0"
+    "unzip-crx-3": "^0.2.0"
   },
   "babel": {
     "presets": [

--- a/src/downloadChromeExtension.js
+++ b/src/downloadChromeExtension.js
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import rimraf from 'rimraf';
-import unzip from 'unzip-crx';
+import unzip from 'unzip-crx-3';
 
 import { getPath, downloadFile, changePermissions } from './utils';
 
@@ -16,7 +16,7 @@ const downloadChromeExtension = (chromeStoreID, forceDownload, attempts = 5) => 
       if (fs.existsSync(extensionFolder)) {
         rimraf.sync(extensionFolder);
       }
-      const fileURL = `https://clients2.google.com/service/update2/crx?response=redirect&x=id%3D${chromeStoreID}%26uc&prodversion=32`; // eslint-disable-line
+      const fileURL = `https://clients2.google.com/service/update2/crx?response=redirect&acceptformat=crx2,crx3&x=id%3D${chromeStoreID}%26uc&prodversion=32`; // eslint-disable-line
       const filePath = path.resolve(`${extensionFolder}.crx`);
       downloadFile(fileURL, filePath)
         .then(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5708,10 +5708,10 @@ unset-value@^1.0.0:
     has-value "^0.3.1"
     isobject "^3.0.0"
 
-unzip-crx@^0.2.0:
+unzip-crx-3@^0.2.0:
   version "0.2.0"
-  resolved "https://registry.yarnpkg.com/unzip-crx/-/unzip-crx-0.2.0.tgz#4c0baa8bdac756256754beca7843c13d7b858c18"
-  integrity sha1-TAuqi9rHViVnVL7KeEPBPXuFjBg=
+  resolved "https://registry.yarnpkg.com/unzip-crx-3/-/unzip-crx-3-0.2.0.tgz#d5324147b104a8aed9ae8639c95521f6f7cda292"
+  integrity sha512-0+JiUq/z7faJ6oifVB5nSwt589v1KCduqIJupNVDoWSXZtWDmjDGO3RAEOvwJ07w90aoXoP4enKsR7ecMrJtWQ==
   dependencies:
     jszip "^3.1.0"
     mkdirp "^0.5.1"


### PR DESCRIPTION
Google servers recently started sending empty replies when
acceptformat=crx2,crx3 is not passed. Add the option to the URL query
and switch to unzip-crx-3, which supports both CRX v2 and v3.

Closes: #139