### PR TITLE
Add support for electron loadExtension options

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ app.whenReady().then(() => {
 ```
 To install multiple extensions, `installExtension` takes an array.
 
+Optionally `installExtension` takes a second `Object` argument of options for electron's [`ses.loadExtension()`](https://www.electronjs.org/docs/api/session#sesloadextensionpath).
+
 ## What extensions can I use?
 
 Technically you can use whatever extension you want.  Simply find the ChromeStore ID

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ if (fs.existsSync(getIDMapPath())) {
   }
 }
 
-const install = (extensionReference, forceDownload = false) => {
+const install = (extensionReference, options = {}, forceDownload = false) => {
   if (process.type !== 'browser') {
     return Promise.reject(
       new Error('electron-devtools-installer can only be used from the main process'),
@@ -25,7 +25,7 @@ const install = (extensionReference, forceDownload = false) => {
 
   if (Array.isArray(extensionReference)) {
     return extensionReference.reduce(
-      (accum, extension) => accum.then(() => install(extension, forceDownload)),
+      (accum, extension) => accum.then(() => install(extension, options, forceDownload)),
       Promise.resolve(),
     );
   }
@@ -79,7 +79,7 @@ const install = (extensionReference, forceDownload = false) => {
 
     // For Electron >=9.
     if (session.defaultSession.loadExtension) {
-      return session.defaultSession.loadExtension(extensionFolder).then((ext) => {
+      return session.defaultSession.loadExtension(extensionFolder, options).then((ext) => {
         return Promise.resolve(ext.name);
       });
     }

--- a/test/install_spec.js
+++ b/test/install_spec.js
@@ -52,7 +52,7 @@ describe('Extension Installer', () => {
                 .find((e) => e.name === extensionName)
                 .version.should.be.equal(oldVersion);
 
-              installExtension(REACT_DEVELOPER_TOOLS, true)
+              installExtension(REACT_DEVELOPER_TOOLS, {}, true)
                 .then(() => {
                   session.defaultSession
                     .getAllExtensions()
@@ -69,7 +69,7 @@ describe('Extension Installer', () => {
           ).should.be.equal(extensionName);
           BrowserWindow.getDevToolsExtensions()[extensionName].version.should.be.equal(oldVersion);
 
-          installExtension(REACT_DEVELOPER_TOOLS, true)
+          installExtension(REACT_DEVELOPER_TOOLS, {}, true)
             .then(() => {
               BrowserWindow.getDevToolsExtensions()[extensionName].version.should.not.be.equal(
                 oldVersion,


### PR DESCRIPTION
Since electron will be exposing a second "options" argument for `loadExtension()` (electron/electron#25198) to enable essential features such as "Allow access to file URLs" for extensions, this is a simple proactive implementation to support that feature. (Possible fix for #164)

Usage: 
```js
installExtension(REDUX_DEVTOOLS, { allowFileAccess: true })
   .then((name) => console.log(`Added Extension:  ${name}`))
   .catch((err) => console.log('An error occurred: ', err));
```