### PR TITLE
Export interfaces ExtensionReference and ExtensionOptions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ if (fs.existsSync(getIDMapPath())) {
   }
 }
 
-interface ExtensionReference {
+export interface ExtensionReference {
   /**
    * Extension ID
    */
@@ -27,7 +27,7 @@ interface ExtensionReference {
   electron: string;
 }
 
-interface ExtensionOptions {
+export interface ExtensionOptions {
   /**
    * Ignore whether the extension is already downloaded and redownload every time
    */


### PR DESCRIPTION
Export interfaces ExtensionReference and ExtensionOptions to enable better linting when passing as a parameter in a wrapper of installExtension function