### PR TITLE
Added custom session and chrome version

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,27 @@ const { default: installExtension, REACT_DEVELOPER_TOOLS } = require('electron-d
 const { app } = require('electron');
 
 app.whenReady().then(() => {
-    installExtension(REDUX_DEVTOOLS)
+    installExtension(REDUX_DEVTOOLS, {
+			loadExtensionOptions: {
+				allowFileAccess: true
+			},
+			forceDownload: true
+		})
+        .then((name) => console.log(`Added Extension:  ${name}`))
+        .catch((err) => console.log('An error occurred: ', err));
+});
+```
+You can add a third param in installExtension to use a custom session, if it is not set then session.defaultSession will be used.
+
+```js
+
+app.whenReady().then(() => {
+    installExtension(REDUX_DEVTOOLS, {
+			loadExtensionOptions: {
+				allowFileAccess: true
+			}
+		},
+    customSession)
         .then((name) => console.log(`Added Extension:  ${name}`))
         .catch((err) => console.log('An error occurred: ', err));
 });

--- a/src/downloadChromeExtension.ts
+++ b/src/downloadChromeExtension.ts
@@ -21,7 +21,7 @@ const downloadChromeExtension = (
       if (fs.existsSync(extensionFolder)) {
         rimraf.sync(extensionFolder);
       }
-      const fileURL = `https://clients2.google.com/service/update2/crx?response=redirect&acceptformat=crx2,crx3&x=id%3D${chromeStoreID}%26uc&prodversion=32`; // eslint-disable-line
+      const fileURL = `https://clients2.google.com/service/update2/crx?response=redirect&acceptformat=crx2,crx3&x=id%3D${chromeStoreID}%26uc&prodversion=${process.versions.chrome}`; // eslint-disable-line
       const filePath = path.resolve(`${extensionFolder}.crx`);
       downloadFile(fileURL, filePath)
         .then(() => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,11 +41,13 @@ interface ExtensionOptions {
 /**
  * @param extensionReference Extension or extensions to install
  * @param options Installation options
+ * @param custom_session A custom session
  * @returns A promise resolving with the name or names of the extensions installed
  */
 const install = (
   extensionReference: ExtensionReference | string | Array<ExtensionReference | string>,
   options: ExtensionOptions | boolean = {},
+  custom_session: any = null
 ): Promise<string> => {
   // Support old forceDownload syntax
   if (typeof options === 'boolean') {
@@ -87,10 +89,11 @@ const install = (
   let extensionInstalled: boolean;
 
   // For Electron >=9.
-  if ((session.defaultSession as any).getExtension) {
+  custom_session = custom_session === null ? session.defaultSession : custom_session;
+  if ((custom_session as any).getExtension) {
     extensionInstalled =
       !!extensionName &&
-      (session.defaultSession as any)
+      (custom_session as any)
         .getAllExtensions()
         .find((e: { name: string }) => e.name === extensionName);
   } else {
@@ -107,19 +110,19 @@ const install = (
     // Use forceDownload, but already installed
     if (extensionInstalled) {
       // For Electron >=9.
-      if ((session.defaultSession as any).removeExtension) {
-        const extensionId = (session.defaultSession as any)
+      if ((custom_session as any).removeExtension) {
+        const extensionId = (custom_session as any)
           .getAllExtensions()
           .find((e: { name: string }) => e.name).id;
-        (session.defaultSession as any).removeExtension(extensionId);
+        (custom_session as any).removeExtension(extensionId);
       } else {
         BrowserWindow.removeDevToolsExtension(extensionName);
       }
     }
 
     // For Electron >=9.
-    if ((session.defaultSession as any).loadExtension) {
-      return (session.defaultSession as any)
+    if ((custom_session as any).loadExtension) {
+      return (custom_session as any)
         .loadExtension(extensionFolder, loadExtensionOptions)
         .then((ext: { name: string }) => {
           return Promise.resolve(ext.name);

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,7 +47,7 @@ interface ExtensionOptions {
 const install = (
   extensionReference: ExtensionReference | string | Array<ExtensionReference | string>,
   options: ExtensionOptions | boolean = {},
-  custom_session: any = null
+  custom_session: any = null,
 ): Promise<string> => {
   // Support old forceDownload syntax
   if (typeof options === 'boolean') {


### PR DESCRIPTION
Now you can use a custom session instead session.defaultSession
The electron chrome version is used to download the right crx extension from Chrome Web Store instead pass chrome version 32.