### PR TITLE
Update VUEJS3_DEVTOOLS extension id

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -166,7 +166,7 @@ export const VUEJS_DEVTOOLS: ExtensionReference = {
   electron: '>=1.2.1',
 };
 export const VUEJS3_DEVTOOLS: ExtensionReference = {
-  id: 'ljjemllljcmogpfapbkkighbhhppjdbg',
+  id: 'nhdogjmejiglipccpnnnanhbledajbpd',
   electron: '>=1.2.1',
 };
 export const REDUX_DEVTOOLS: ExtensionReference = {


### PR DESCRIPTION
* [Old link](https://chrome.google.com/webstore/detail/vuejs-devtools/ljjemllljcmogpfapbkkighbhhppjdbg): ljjemllljcmogpfapbkkighbhhppjdbg
* [New Link](https://chrome.google.com/webstore/detail/vuejs-devtools/nhdogjmejiglipccpnnnanhbledajbpd): nhdogjmejiglipccpnnnanhbledajbpd

I noticed when using the tools in my test app that routing stopped
working once I opened the tools.  Doing some research I found
[this issue](https://github.com/vuejs/router/issues/1338) about the
router that said it only happens when using the 6.0 beta version of
the devtools.  Looking at the extension directory installed with
this it does reference the beta:

```js
  "version": "6.0.0.21",
  "version_name": "6.0.0 beta 21",
```

Using the new id (nndogjme...) in my code instead of VUEJS3_DEVTOOLS
fixed the issue for me.  Also the new one seems to be more current
(March 30 2022 vs. December 20, 2021), is newer (6.1.4 vs. 6.0.0.21),
has more stars (1808 vs. 127) and more users (1,000,000+ vs. 200,000+).