### PR TITLE
Use the latest Vue devtools extension

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -166,7 +166,7 @@ export const VUEJS_DEVTOOLS: ExtensionReference = {
   electron: '>=1.2.1',
 };
 export const VUEJS3_DEVTOOLS: ExtensionReference = {
-  id: 'ljjemllljcmogpfapbkkighbhhppjdbg',
+  id: 'nhdogjmejiglipccpnnnanhbledajbpd',
   electron: '>=1.2.1',
 };
 export const REDUX_DEVTOOLS: ExtensionReference = {


### PR DESCRIPTION
The old beta devtools lead to potential errors in the electron app, when the vue devtools are open. These problems are solved with the new extension version.

Link to [vue devtools in the chrome store](https://chrome.google.com/webstore/detail/vuejs-devtools/nhdogjmejiglipccpnnnanhbledajbpd)