### PR TITLE
updated vuejs3 new extention version

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -166,7 +166,7 @@ export const VUEJS_DEVTOOLS: ExtensionReference = {
   electron: '>=1.2.1',
 };
 export const VUEJS3_DEVTOOLS: ExtensionReference = {
-  id: 'ljjemllljcmogpfapbkkighbhhppjdbg',
+  id: 'nhdogjmejiglipccpnnnanhbledajbpd',
   electron: '>=1.2.1',
 };
 export const REDUX_DEVTOOLS: ExtensionReference = {


### PR DESCRIPTION
We have problem in new vue-router versions:

> vue-router.mjs:2541 [Vue Router]: You seem to be using an outdated version of Vue Devtools. Are you still using the Beta release instead of the stable one? You can find the links at https://devtools.vuejs.org/guide/installation.html.

BTW after open vue-dev-tools then, vue-router not work anymore.

```
vue-router.mjs:2614 Uncaught (in promise) TypeError: api.now is not a function
    at vue-router.mjs:2614:31
    at vue-router.mjs:3445:37
    at Array.forEach (<anonymous>)
    at triggerError (vue-router.mjs:3445:18)
    at vue-router.mjs:3173:17
```

So we need to update extention
