### PR TITLE
fix: map `prodversion` param to `process.versions`

### DIFF
--- a/src/downloadChromeExtension.ts
+++ b/src/downloadChromeExtension.ts
@@ -21,7 +21,7 @@ const downloadChromeExtension = (
       if (fs.existsSync(extensionFolder)) {
         rimraf.sync(extensionFolder);
       }
-      const fileURL = `https://clients2.google.com/service/update2/crx?response=redirect&acceptformat=crx2,crx3&x=id%3D${chromeStoreID}%26uc&prodversion=32`; // eslint-disable-line
+      const fileURL = `https://clients2.google.com/service/update2/crx?response=redirect&acceptformat=crx2,crx3&x=id%3D${chromeStoreID}%26uc&prodversion=${process.versions.chrome}`; // eslint-disable-line
       const filePath = path.resolve(`${extensionFolder}.crx`);
       downloadFile(fileURL, filePath)
         .then(() => {


### PR DESCRIPTION
Fixes #249.

In Electron, `process.versions.chrome` maps to the Chromium version currently used by the Electron binary.

This fix may break things for users on older versions of Electron depending on what the Chrome extension manifest's [`minimum_chrome_version`](https://developer.chrome.com/docs/extensions/reference/manifest/minimum-chrome-version) key is.

For example, React Dev Tools currently has their min version set to v102, meaning that only Electron 19+ will work.